### PR TITLE
adapt tutorial for Dancer 2

### DIFF
--- a/README
+++ b/README
@@ -1,0 +1,3 @@
+This is the code from Dancer::Tutorial as a working example for your convenience. This version of the tutorial is intended for Dancer 2.x. 
+
+(There are not so many differences between Dancer 1 and 2 for the application developer, so Dancer::Tutorial remains largely the same as in Dancer 1.x.)

--- a/dancr.pl
+++ b/dancr.pl
@@ -1,117 +1,114 @@
 #!/usr/bin/perl
 
-use Dancer;
+use Dancer 2.0;
 use DBI;
 use File::Spec;
 use File::Slurp;
 use Template;
- 
+
 set 'database'     => File::Spec->catfile(File::Spec->tmpdir(), 'dancr.db');
 set 'session'      => 'Simple';
 set 'template'     => 'template_toolkit';
-set 'logger'       => 'console';
-set 'log'          => 'debug';
-set 'show_errors'  => 1;
-set 'startup_info' => 1;
-set 'warnings'     => 1;
+set 'logger'       => 'console';    #not default value?
+set 'log'          => 'info';
+set 'show_errors'  => 1;            #not yet implemented in D2
+set 'startup_info' => 1;            #not yet implemented in D2
+set 'warnings'     => 1;            #?
 set 'username'     => 'admin';
 set 'password'     => 'password';
 set 'layout'       => 'main';
- 
+
 my $flash;
- 
+
 sub set_flash {
-       my $message = shift;
- 
-       $flash = $message;
+    my $message = shift;
+    $flash = $message;
 }
- 
+
 sub get_flash {
- 
-       my $msg = $flash;
-       $flash = "";
- 
-       return $msg;
+    my $msg = $flash;
+    $flash = "";
+
+    return $msg;
 }
- 
+
 sub connect_db {
-       my $dbh = DBI->connect("dbi:SQLite:dbname=".setting('database')) or
-               die $DBI::errstr;
- 
-       return $dbh;
+    my $dbh = DBI->connect("dbi:SQLite:dbname=" . setting('database'))
+      or die $DBI::errstr;
+
+    return $dbh;
 }
- 
+
 sub init_db {
-       my $db = connect_db();
-       my $schema = read_file('./schema.sql');
-       $db->do($schema) or die $db->errstr;
+    my $db     = connect_db();
+    my $schema = read_file('./schema.sql');
+    $db->do($schema) or die $db->errstr;
 }
- 
+
 hook before_template => sub {
-       my $tokens = shift;
-        
-       $tokens->{'css_url'} = request->base . 'css/style.css';
-       $tokens->{'login_url'} = uri_for('/login');
-       $tokens->{'logout_url'} = uri_for('/logout');
+    my $tokens = shift;
+
+    $tokens->{'css_url'}    = request->base . 'css/style.css';
+    $tokens->{'login_url'}  = uri_for('/login');
+    $tokens->{'logout_url'} = uri_for('/logout');
 };
- 
+
 get '/' => sub {
-       my $db = connect_db();
-       my $sql = 'select id, title, text from entries order by id desc';
-       my $sth = $db->prepare($sql) or die $db->errstr;
-       $sth->execute or die $sth->errstr;
-       template 'show_entries.tt', {
-               'msg' => get_flash(),
-               'add_entry_url' => uri_for('/add'),
-               'entries' => $sth->fetchall_hashref('id'),
-       };
+    my $db  = connect_db();
+    my $sql = 'select id, title, text from entries order by id desc';
+    my $sth = $db->prepare($sql) or die $db->errstr;
+    $sth->execute or die $sth->errstr;
+    template 'show_entries.tt',
+      { 'msg'           => get_flash(),
+        'add_entry_url' => uri_for('/add'),
+        'entries'       => $sth->fetchall_hashref('id'),
+      };
 };
- 
+
 post '/add' => sub {
-       if ( not session('logged_in') ) {
-               send_error("Not logged in", 401);
-       }
- 
-       my $db = connect_db();
-       my $sql = 'insert into entries (title, text) values (?, ?)';
-       my $sth = $db->prepare($sql) or die $db->errstr;
-       $sth->execute(params->{'title'}, params->{'text'}) or die $sth->errstr;
- 
-       set_flash('New entry posted!');
-       redirect '/';
+    if (not session('logged_in')) {
+        send_error("Not logged in", 401);
+    }
+
+    my $db  = connect_db();
+    my $sql = 'insert into entries (title, text) values (?, ?)';
+    my $sth = $db->prepare($sql) or die $db->errstr;
+    $sth->execute(params->{'title'}, params->{'text'}) or die $sth->errstr;
+
+    set_flash('New entry posted!');
+    redirect '/';
 };
- 
+
 any ['get', 'post'] => '/login' => sub {
-       my $err;
- 
-       if ( request->method() eq "POST" ) {
-               # process form input
-               if ( params->{'username'} ne setting('username') ) {
-                       $err = "Invalid username";
-               }
-               elsif ( params->{'password'} ne setting('password') ) {
-                       $err = "Invalid password";
-               }
-               else {
-                       session 'logged_in' => true;
-                       set_flash('You are logged in.');
-                       return redirect '/';
-               }
-       }
- 
-       # display login form
-       template 'login.tt', {
-               'err' => $err,
-       };
- 
+    my $err;
+
+    if (request->method() eq "POST") {
+
+        # process form input
+        if (params->{'username'} ne setting('username')) {
+            $err = "Invalid username";
+        }
+        elsif (params->{'password'} ne setting('password')) {
+            $err = "Invalid password";
+        }
+        else {
+            session 'logged_in' => true;
+            set_flash('You are logged in.');
+            return redirect '/';
+        }
+    }
+
+    # display login form
+    template 'login.tt', {'err' => $err,};
+
 };
- 
+
 get '/logout' => sub {
-       session->destroy;
-       set_flash('You are logged out.');
-       redirect '/';
+    session->destroy;
+    set_flash('You are logged out.');
+    redirect '/';
 };
- 
+
 init_db();
 start;
 

--- a/views/layouts/main.tt
+++ b/views/layouts/main.tt
@@ -2,22 +2,22 @@
 <html>
 <head>
   <title>Dancr</title>
-  <link rel=stylesheet type=text/css href="<% css_url %>">
+  <link rel=stylesheet type=text/css href="[% css_url %]">
 </head>
 <body>
   <div class=page>
   <h1>Dancr</h1>
      <div class=metanav>
-     <% IF not session.logged_in %>
-       <a href="<% login_url %>">log in</a>
-     <% ELSE %>
-       <a href="<% logout_url %>">log out</a>
-     <% END %>
+     [% IF not session.logged_in %]
+       <a href="[% login_url %]">log in</a>
+     [% ELSE %]
+       <a href="[% logout_url %]">log out</a>
+     [% END %]
   </div>
-  <% IF msg %>
-    <div class=flash> <% msg %> </div>
-  <% END %>
-  <% content %>
+  [% IF msg %]
+    <div class=flash> [% msg %] </div>
+  [% END %]
+  [% content %]
 </div>
 </body>
 </html>

--- a/views/login.tt
+++ b/views/login.tt
@@ -1,6 +1,6 @@
 <h2>Login</h2>
-<% IF err %><p class=error><strong>Error:</strong> <% err %><% END %>
-<form action="<% login_url %>" method=post>
+[% IF err %]<p class=error><strong>Error:</strong> [% err %][% END %]
+<form action="[% login_url %]" method=post>
   <dl>
     <dt>Username:
     <dd><input type=text name=username>

--- a/views/show_entries.tt
+++ b/views/show_entries.tt
@@ -1,5 +1,5 @@
-<% IF session.logged_in %>
-  <form action="<% add_entry_url %>" method=post class=add-entry>
+[% IF session.logged_in %]
+  <form action="[% add_entry_url %]" method=post class=add-entry>
     <dl>
       <dt>Title:
       <dd><input type=text size=30 name=title>
@@ -8,13 +8,13 @@
       <dd><input type=submit value=Share>
     </dl>
   </form>
-<% END %>
+[% END %]
 <ul class=entries>
-<% IF entries.size %>
-  <% FOREACH id IN entries.keys.nsort %>
-    <li><h2><% entries.$id.title %></h2><% entries.$id.text %>
-  <% END %>
-<% ELSE %>
+[% IF entries.size %]
+  [% FOREACH id IN entries.keys.nsort %]
+    <li><h2>[% entries.$id.title %]</h2>[% entries.$id.text %]
+  [% END %]
+[% ELSE %]
   <li><em>Unbelievable.  No entries here so far</em>
-<% END %>
+[% END %]
 </ul>


### PR DESCRIPTION
I thought I check if I can translate anything from D1 to D2 and then thought of  Dancer::Tutorial next. It almost runs under D2 as is, except for the template default tags [% %]. 

I thought I suggest a new branch for D2, but Github lets me make a PR only into the existing branch which doesn't really make sense here. Thought we keep two different branches for D1 and D2. Anyways, please have a look, change it etc.  

I could also make a PR for the D2's Dancer::Tutorial.pod once you're done and if you don't want to do it yourself.

Sorry for the whitespace changes. I hope you have perltidy at hand to re-format to whatever you were using earlier. (Perhaps include .perltidyrc in repository?)
